### PR TITLE
Today 버튼 클릭시 달력이 오늘날짜 페이지로 넘어오는 기능추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,6 +115,12 @@ class _MyHomePageState extends State<MyHomePage> {
                 selectedDayPredicate: (DateTime day) {
                   return isSameDay(selectedDay, day);
                 },
+                onFormatChanged: (format) {
+                  setState(() {
+                    DateTime today = createTimeForEvent(DateTime.now());
+                    focusedDay = today;
+                  });
+                },
               ),
               todoList.isEmpty
                   ? Expanded(child: Center(child: Text("메모를 작성해 주세요")))

--- a/lib/todo_service.dart
+++ b/lib/todo_service.dart
@@ -100,17 +100,17 @@ class TodoService extends ChangeNotifier {
   }
 
   saveMemoList() {
-    List todoJsonList = todoList.map((memo) => memo.toJson()).toList();
+    List todoJsonList = todoList.map((todo) => todo.toJson()).toList();
     String jsonString = jsonEncode(todoJsonList);
-    prefs.setString('memoList', jsonString);
+    prefs.setString('TodoList', jsonString);
   }
 
   loadMemoList() {
-    String? jsonString = prefs.getString('memoList');
+    String? jsonString = prefs.getString('TodoList');
     if (jsonString == null) return; // null 이면 로드하지 않음
-    List memoJsonList = jsonDecode(jsonString);
+    List todoJsonList = jsonDecode(jsonString);
 
-    todoList = memoJsonList.map((json) => Todo.fromJson(json)).toList();
+    todoList = todoJsonList.map((json) => Todo.fromJson(json)).toList();
     for (var todo in todoList) {
       addEvent(todo);
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -320,10 +320,11 @@ packages:
   table_calendar:
     dependency: "direct main"
     description:
-      name: table_calendar
-      sha256: "1e3521a3e6d3fc7f645a58b135ab663d458ab12504f1ea7f9b4b81d47086c478"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: HEAD
+      resolved-ref: "63977b79411351ce3281fb28531fb0d7faf6e59e"
+      url: "https://github.com/three523/table_calendar.git"
+    source: git
     version: "3.0.9"
   term_glyph:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,11 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  table_calendar: ^3.0.9
+  table_calendar:
+    git:
+      url: https://github.com/three523/table_calendar.git
+
+
   provider: ^6.0.5
   shared_preferences: ^2.1.2
   


### PR DESCRIPTION
기존 table-calendar 깃허브 링크에서 https://github.com/three523/table_calendar 제 깃허브 링크로 수정되었습니다.
todo_service에 파일 데이터 가져오는 부분에 memoList라고 되어있는 부분 todoList로 변경하였습니다.